### PR TITLE
Added redcarpet gem to parse Meetup description markdown into HTML tag.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,3 +87,7 @@ gem 'pg_search', '~> 2.3.0'
 
 # Open URI to connect to event collector API
 gem 'open-uri'
+
+# Redcarper parses Meetup markdown to HTML
+# https://web-crunch.com/posts/how-to-add-markdown-support-to-ruby-on-rails
+gem "redcarpet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     autoprefixer-rails (10.2.5.0)
       execjs (< 2.8.0)
     aws_cf_signer (0.1.3)
-    bcrypt (3.1.17)
+    bcrypt (3.1.18)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -85,12 +85,12 @@ GEM
     bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
-    blazer (2.6.2)
+    blazer (2.6.4)
       activerecord (>= 5)
       chartkick (>= 3.2)
       railties (>= 5)
       safely_block (>= 0.1.1)
-    bootsnap (1.11.1)
+    bootsnap (1.12.0)
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
@@ -111,7 +111,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
-    date (3.1.3)
+    date (3.2.2)
     debug_inspector (1.1.0)
     device_detector (1.0.7)
     devise (4.8.1)
@@ -138,7 +138,7 @@ GEM
     globalid (1.0.0)
       activesupport (>= 5.0)
     http-accept (1.7.0)
-    http-cookie (1.0.4)
+    http-cookie (1.0.5)
       domain_name (~> 0.5)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
@@ -161,14 +161,12 @@ GEM
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
     minitest (5.15.0)
-    msgpack (1.5.1)
+    msgpack (1.5.2)
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.13.6-x86_64-darwin)
-      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
-    open-uri (0.1.0)
+    open-uri (0.2.0)
       stringio
       time
       uri
@@ -191,7 +189,7 @@ GEM
     pundit (2.2.0)
       activesupport (>= 3.0.0)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-mini-profiler (2.3.4)
       rack (>= 1.2.0)
     rack-proxy (0.7.2)
@@ -228,8 +226,9 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     redis (4.6.0)
-    regexp_parser (2.4.0)
+    regexp_parser (2.5.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -252,10 +251,11 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.1.0)
+    selenium-webdriver (4.2.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     semantic_range (3.0.0)
     spring (4.0.0)
     sprockets (4.0.3)
@@ -265,10 +265,10 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    stringio (3.0.1)
+    stringio (3.0.2)
     thor (1.2.1)
     tilt (2.0.10)
-    time (0.1.0)
+    time (0.2.0)
       date
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -277,8 +277,8 @@ GEM
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8.1)
-    uri (0.10.1)
+    unf_ext (0.0.8.2)
+    uri (0.11.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -295,6 +295,7 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -303,8 +304,6 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
-  x86_64-darwin-20
-  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -333,6 +332,7 @@ DEPENDENCIES
   pundit
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.5, >= 6.1.5.1)
+  redcarpet
   redis (~> 4.0)
   sass-rails (>= 6)
   selenium-webdriver (>= 4.0.0.rc1)
@@ -348,4 +348,4 @@ RUBY VERSION
    ruby 3.0.3p157
 
 BUNDLED WITH
-   2.3.7
+   2.3.4

--- a/app/assets/stylesheets/pages/_show.scss
+++ b/app/assets/stylesheets/pages/_show.scss
@@ -8,6 +8,12 @@
   }
 }
 
+#offer-description {
+  li {
+    margin-left: 16px;
+  }
+}
+
 .card-offer-details {
   border: 1px solid $blue;
   border-radius: 8px;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,8 @@
+require 'redcarpet'
+
 module ApplicationHelper
+  def markdown(text)
+    options = [:hard_wrap, :autolink, :no_intra_emphasis, :fenced_code_blocks]
+    Markdown.new(text, *options).to_html.html_safe
+  end
 end

--- a/app/views/offers/show.html.erb
+++ b/app/views/offers/show.html.erb
@@ -1,3 +1,4 @@
+
 <!-- info / title/ short description / Star rating / Add to wishlist-->
 <div class="container mt-4" data-controller="insert-review">
   <div id="offer-header" class="row">
@@ -61,7 +62,7 @@
     <div class="col col-md-8">
       <div id="offer-description" class="row mt-5">
         <h3>Read more about the experience you're going to</h3>
-        <p><%= @offer.description %></p>
+        <p><%= markdown(@offer.description) %></p>
       </div>
 
       <div id="offer-reviews" class="row col col-md-10 mt-4"> <%# col-7 %>


### PR DESCRIPTION
Redcarpet Gem takes meetup descriptions (mardown format) and parses them into HTML.
https://web-crunch.com/posts/how-to-add-markdown-support-to-ruby-on-rails

![image](https://user-images.githubusercontent.com/34220538/171053090-c34890a9-ecb9-40a7-9bd2-288c2787ca21.png)

![image](https://user-images.githubusercontent.com/34220538/171053110-2e346d14-7ca6-42fc-8e48-6f15fc04fa29.png)
