### PR TITLE
Offers longitude check

### DIFF
--- a/app/assets/stylesheets/pages/_dashboard.scss
+++ b/app/assets/stylesheets/pages/_dashboard.scss
@@ -68,6 +68,29 @@
   }
 }
 
+.conversation-details-box {
+  overflow-y: scroll;
+  height: 80vh;
+  position: relative;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  h2 {
+    position: sticky;
+    top: 0px;
+    left: 0px;
+    background-color: white;
+    z-index: 50;
+    right: 0px;
+    padding: 20px 0px;
+  }
+  .enter-message-section {
+    position: sticky;
+    bottom: 0px;
+    background-color: white;
+    padding-bottom: 12px;
+  }
+}
+
 .card-sport-category {
   border: 1px solid $inactive-gray;
   border-radius: 8px;

--- a/app/views/conversations/_message_form.html.erb
+++ b/app/views/conversations/_message_form.html.erb
@@ -1,6 +1,8 @@
-<hr>
+<div class="enter-message-section">
+  <hr>
   <%= simple_form_for @message, html: { class: "new-message-input"} do |f| %>
     <%= hidden_field_tag 'conversation_id', @conversation.id %>
     <%= f.input :content, label: false, placeholder: 'Write a message...'%>
     <%= f.submit "Send message", class: 'btn btn-slim-secondary' %>
   <% end %>
+</div>

--- a/app/views/dashboard/_conversations.html.erb
+++ b/app/views/dashboard/_conversations.html.erb
@@ -14,7 +14,7 @@
       </div>
     </div>
     <% if @conversation %>
-      <div class="col-7 card-profile mt-5">
+      <div class="col-7 card-profile mt-5 conversation-details-box">
         <div class="d-flex flex-column">
           <%= render 'conversation-details', conversation: @conversation %>
         </div>

--- a/app/views/dashboard/_conversations.html.erb
+++ b/app/views/dashboard/_conversations.html.erb
@@ -1,7 +1,6 @@
-<div class="container">
   <div class="row">
     <div class="col-4 card-profile mt-5">
-      <div class="d-flex flex-column">
+      <div class="d-flex flex-column justify-content-start">
         <h2>Your Conversations</h2>
         <br>
         <% if @conversations.present? %>
@@ -21,4 +20,3 @@
       </div>
     <% end %>
   </div>
-</div>


### PR DESCRIPTION
- Hopefully the very last offer_controller updated. The issue was that at some places the .near() method was used 2x in a row. This caused an Active Record error due to a duplicate column name from the Geocoder gem. 
- Added a scrollbar to conversation details. Order of messages can be still changed. 