### PR TITLE
Added and styled link_to Offer#Show in headings on Dashboard

### DIFF
--- a/app/assets/stylesheets/pages/_dashboard.scss
+++ b/app/assets/stylesheets/pages/_dashboard.scss
@@ -68,12 +68,24 @@
   }
 }
 
+.link-hover-red {
+  a {
+    text-decoration-line: none;
+
+    &:hover, &:hover > h2 > span {
+      color: $coral;
+    }
+  }
+}
+
 .conversation-details-box {
   overflow-y: scroll;
   height: 80vh;
   position: relative;
   padding-top: 0px;
   padding-bottom: 0px;
+
+
   h2 {
     position: sticky;
     top: 0px;
@@ -83,6 +95,7 @@
     right: 0px;
     padding: 20px 0px;
   }
+
   .enter-message-section {
     position: sticky;
     bottom: 0px;

--- a/app/views/dashboard/_bookings-details.html.erb
+++ b/app/views/dashboard/_bookings-details.html.erb
@@ -1,5 +1,5 @@
-<div>
-  <h2><%= @offer.title %></h2>
+<div class="link-hover-red">
+  <h2><%= link_to @offer.title, offer_path(@offer) %></h2>
   <br>
   <%= @offer.description %>
   <div class="col col-md-7">

--- a/app/views/dashboard/_conversation-details.html.erb
+++ b/app/views/dashboard/_conversation-details.html.erb
@@ -1,11 +1,11 @@
-<%= link_to "/offers/#{conversation.offer_id}" do %>
-  <h2 class="text-decoration-none">Conversation with <%= conversation.with(current_user).first_name %>
-      about <span><%= conversation.offer.title %></span>
-  </h2>
-<% end %>
-<br>
-<% conversation.messages.reorder('messages.created_at ASC').each do |message| %>
-  <%= render 'shared/message_card', message: message %>
-<% end %>
-<br>
-<%= render 'conversations/message_form' %>
+<div class="link-hover-red">
+  <%= link_to "/offers/#{conversation.offer_id}" do %>
+    <h2 class="text-decoration-none">Conversation with <%= conversation.with(current_user).first_name %>
+        about <span><%= conversation.offer.title %></span>
+    </h2>
+  <% end %>
+  <% conversation.messages.reorder('messages.created_at ASC').each do |message| %>
+    <%= render 'shared/message_card', message: message %>
+  <% end %>
+  <%= render 'conversations/message_form' %>
+</div>

--- a/app/views/dashboard/_wishlist_details.html.erb
+++ b/app/views/dashboard/_wishlist_details.html.erb
@@ -1,5 +1,5 @@
-<div>
-  <h2><%= @offer.title %></h2>
+<div class="link-hover-red">
+  <h2><%= link_to @offer.title, offer_path(@offer) %></h2>
   <br>
   <%= @offer.description %>
   <div class="col col-md-7 mt-5">


### PR DESCRIPTION
Currently either the whole heading or part of it (only the offer title in Conversations section) turns coral on :hover.

The CSS class is "link-hover-red" in dashboard's SCSS file.